### PR TITLE
ComponentPrefabs path fixed on editor MaterialUIEditorTools class

### DIFF
--- a/Editor/MaterialUIEditorTools.cs
+++ b/Editor/MaterialUIEditorTools.cs
@@ -45,7 +45,7 @@ namespace MaterialUI
 			{
 				if (!GameObject.FindObjectOfType<UnityEngine.EventSystems.EventSystem>())
 				{
-					GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/ComponentPrefabs/EventSystem.prefab",
+					GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/Runtime/ComponentPrefabs/EventSystem.prefab",
 						typeof (GameObject))).name = "EventSystem";
 				}
 
@@ -56,7 +56,7 @@ namespace MaterialUI
 				else
 				{
 					selectedObject =
-						GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/ComponentPrefabs/Canvas.prefab",
+						GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/Runtime/ComponentPrefabs/Canvas.prefab",
 							typeof (GameObject))) as GameObject;
 					selectedObject.name = "Canvas";
 				}
@@ -73,7 +73,7 @@ namespace MaterialUI
 		private static void CreateBackground()
 		{
 			theThing =
-				GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/ComponentPrefabs/Background.prefab",
+				GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/Runtime/ComponentPrefabs/Background.prefab",
 					typeof (GameObject))) as GameObject;
 			SetupObject("Background");
 			theThing.GetComponent<RectTransform>().sizeDelta = Vector2.zero;
@@ -84,7 +84,7 @@ namespace MaterialUI
 		private static void CreatePanel()
 		{
 			theThing =
-				GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/ComponentPrefabs/Panel.prefab",
+				GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/Runtime/ComponentPrefabs/Panel.prefab",
 					typeof (GameObject))) as GameObject;
 			SetupObject("Panel");
 		}
@@ -94,7 +94,7 @@ namespace MaterialUI
 		private static void CreateText()
 		{
 			theThing =
-				GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/ComponentPrefabs/Text.prefab",
+				GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/Runtime/ComponentPrefabs/Text.prefab",
 				                                                     typeof (GameObject))) as GameObject;
 			SetupObject("Text");
 		}
@@ -104,7 +104,7 @@ namespace MaterialUI
 		private static void CreateButtonFlat()
 		{
 			theThing =
-				GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/ComponentPrefabs/Button - Flat.prefab",
+				GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/Runtime/ComponentPrefabs/Button - Flat.prefab",
 					typeof (GameObject))) as GameObject;
 			SetupObject("Button - Flat");
 		}
@@ -114,7 +114,7 @@ namespace MaterialUI
 		private static void CreateButtonRaised()
 		{
 			theThing =
-				GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/ComponentPrefabs/Button - Raised.prefab",
+				GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/Runtime/ComponentPrefabs/Button - Raised.prefab",
 					typeof (GameObject))) as GameObject;
 			SetupObject("Button - Raised");
 		}
@@ -125,7 +125,7 @@ namespace MaterialUI
 		{
 			theThing =
 				GameObject.Instantiate(AssetDatabase.LoadAssetAtPath(
-					"Packages/com.battlefieldnoob.uimaterialelements/ComponentPrefabs/Round Button - Flat.prefab", typeof (GameObject))) as GameObject;
+					"Packages/com.battlefieldnoob.uimaterialelements/Runtime/ComponentPrefabs/Round Button - Flat.prefab", typeof (GameObject))) as GameObject;
 			SetupObject("Round Button - Flat");
 		}
 
@@ -135,7 +135,7 @@ namespace MaterialUI
 		{
 			theThing =
 				GameObject.Instantiate(
-					AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/ComponentPrefabs/Round Button - Raised.prefab",
+					AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/Runtime/ComponentPrefabs/Round Button - Raised.prefab",
 						typeof (GameObject))) as GameObject;
 			SetupObject("Round Button - Raised");
 		}
@@ -146,7 +146,7 @@ namespace MaterialUI
 		{
 			theThing =
 				GameObject.Instantiate(
-					AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/ComponentPrefabs/Round Button - Small - Flat.prefab",
+					AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/Runtime/ComponentPrefabs/Round Button - Small - Flat.prefab",
 						typeof (GameObject))) as GameObject;
 			SetupObject("Small Round Button - Flat");
 		}
@@ -157,7 +157,7 @@ namespace MaterialUI
 		{
 			theThing =
 				GameObject.Instantiate(
-					AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/ComponentPrefabs/Round Button - Small - Raised.prefab",
+					AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/Runtime/ComponentPrefabs/Round Button - Small - Raised.prefab",
 						typeof (GameObject))) as GameObject;
 			SetupObject("Small Round Button - Raised");
 		}
@@ -168,7 +168,7 @@ namespace MaterialUI
 		{
 			theThing =
 				GameObject.Instantiate(AssetDatabase.LoadAssetAtPath(
-					"Packages/com.battlefieldnoob.uimaterialelements/ComponentPrefabs/SpinnyArrow Button.prefab", typeof (GameObject))) as GameObject;
+					"Packages/com.battlefieldnoob.uimaterialelements/Runtime/ComponentPrefabs/SpinnyArrow Button.prefab", typeof (GameObject))) as GameObject;
 			SetupObject("Spinny Arrow Button");
 		}
 
@@ -177,7 +177,7 @@ namespace MaterialUI
 		private static void CreateCheckbox()
 		{
 			theThing =
-				GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/ComponentPrefabs/Checkbox.prefab",
+				GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/Runtime/ComponentPrefabs/Checkbox.prefab",
 					typeof (GameObject))) as GameObject;
 			SetupObject("Checkbox");
 		}
@@ -187,7 +187,7 @@ namespace MaterialUI
 		private static void CreateRadioButtons()
 		{
 			theThing =
-				GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/ComponentPrefabs/RadioGroup.prefab",
+				GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/Runtime/ComponentPrefabs/RadioGroup.prefab",
 					typeof (GameObject))) as GameObject;
 			SetupObject("Radio Buttons");
 		}
@@ -197,7 +197,7 @@ namespace MaterialUI
 		private static void CreateSwitch()
 		{
 			theThing =
-				GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/ComponentPrefabs/Switch.prefab",
+				GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/Runtime/ComponentPrefabs/Switch.prefab",
 					typeof (GameObject))) as GameObject;
 			SetupObject("Switch");
 		}
@@ -207,7 +207,7 @@ namespace MaterialUI
 		private static void CreateTextInput()
 		{
 			theThing =
-				GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/ComponentPrefabs/TextInput.prefab",
+				GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/Runtime/ComponentPrefabs/TextInput.prefab",
 					typeof (GameObject))) as GameObject;
 			SetupObject("Text Input");
 		}
@@ -217,7 +217,7 @@ namespace MaterialUI
 		private static void CreateSlider()
 		{
 			theThing =
-				GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/ComponentPrefabs/Slider.prefab",
+				GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/Runtime/ComponentPrefabs/Slider.prefab",
 					typeof (GameObject))) as GameObject;
 			SetupObject("Slider");
 		}
@@ -227,7 +227,7 @@ namespace MaterialUI
 		private static void CreateSliderLabel()
 		{
 			theThing =
-				GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/ComponentPrefabs/Slider_label.prefab",
+				GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/Runtime/ComponentPrefabs/Slider_label.prefab",
 					typeof(GameObject))) as GameObject;
 			SetupObject("Slider");
 		}
@@ -237,7 +237,7 @@ namespace MaterialUI
 		private static void CreateSliderLabelValue()
 		{
 			theThing =
-				GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/ComponentPrefabs/Slider_label_value.prefab",
+				GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/Runtime/ComponentPrefabs/Slider_label_value.prefab",
 					typeof(GameObject))) as GameObject;
 			SetupObject("Slider");
 		}
@@ -247,7 +247,7 @@ namespace MaterialUI
 		private static void CreateSelectionBox()
 		{
 			theThing =
-				GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/ComponentPrefabs/SelectionBox.prefab",
+				GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/Runtime/ComponentPrefabs/SelectionBox.prefab",
 					typeof (GameObject))) as GameObject;
 			SetupObject("Selection Box");
 		}
@@ -258,7 +258,7 @@ namespace MaterialUI
 		{
 			theThing =
 				GameObject.Instantiate(AssetDatabase.LoadAssetAtPath(
-					"Packages/com.battlefieldnoob.uimaterialelements/ComponentPrefabs/SelectionBox - Flat.prefab", typeof (GameObject))) as GameObject;
+					"Packages/com.battlefieldnoob.uimaterialelements/Runtime/ComponentPrefabs/SelectionBox - Flat.prefab", typeof (GameObject))) as GameObject;
 			SetupObject("Selection Box - Flat");
 		}
 
@@ -268,7 +268,7 @@ namespace MaterialUI
 		{
 			theThing =
 				GameObject.Instantiate(AssetDatabase.LoadAssetAtPath(
-					"Packages/com.battlefieldnoob.uimaterialelements/ComponentPrefabs/DialogBox - Normal.prefab", typeof (GameObject))) as GameObject;
+					"Packages/com.battlefieldnoob.uimaterialelements/Runtime/ComponentPrefabs/DialogBox - Normal.prefab", typeof (GameObject))) as GameObject;
 			SetupObject("Dialog Box - Normal");
 			theThing.GetComponent<RectTransform>().anchoredPosition = Vector2.zero;
 		}
@@ -279,7 +279,7 @@ namespace MaterialUI
 		{
 			theThing =
 				GameObject.Instantiate(AssetDatabase.LoadAssetAtPath(
-					"Packages/com.battlefieldnoob.uimaterialelements/ComponentPrefabs/DialogBox - Scroll.prefab", typeof (GameObject))) as GameObject;
+					"Packages/com.battlefieldnoob.uimaterialelements/Runtime/ComponentPrefabs/DialogBox - Scroll.prefab", typeof (GameObject))) as GameObject;
 			SetupObject("Dialog Box - Scroll");
 			theThing.GetComponent<RectTransform>().anchoredPosition = Vector2.zero;
 		}
@@ -290,7 +290,7 @@ namespace MaterialUI
 		{
 			theThing =
 				GameObject.Instantiate(AssetDatabase.LoadAssetAtPath(
-					"Packages/com.battlefieldnoob.uimaterialelements/ComponentPrefabs/DialogBox - Simple.prefab", typeof (GameObject))) as GameObject;
+					"Packages/com.battlefieldnoob.uimaterialelements/Runtime/ComponentPrefabs/DialogBox - Simple.prefab", typeof (GameObject))) as GameObject;
 			SetupObject("Dialog Box - Simple");
 			theThing.GetComponent<RectTransform>().anchoredPosition = Vector2.zero;
 		}
@@ -299,7 +299,7 @@ namespace MaterialUI
 		[MenuItem("MaterialUI/Create/Divider/Light", false, 13)]
 		private static void CreateDividerLight()
 		{
-			theThing = GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/ComponentPrefabs/Divider - Light.prefab", typeof(GameObject))) as GameObject;
+			theThing = GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/Runtime/ComponentPrefabs/Divider - Light.prefab", typeof(GameObject))) as GameObject;
 			SetupObject("Divider");
 			theThing.GetComponent<RectTransform>().anchoredPosition = Vector2.zero;
 		}
@@ -308,7 +308,7 @@ namespace MaterialUI
 		[MenuItem("MaterialUI/Create/Divider/Dark", false, 13)]
 		private static void CreateDividerDark()
 		{
-			theThing = GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/ComponentPrefabs/Divider - Dark.prefab", typeof(GameObject))) as GameObject;
+			theThing = GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/Runtime/ComponentPrefabs/Divider - Dark.prefab", typeof(GameObject))) as GameObject;
 			SetupObject("Divider");
 			theThing.GetComponent<RectTransform>().anchoredPosition = Vector2.zero;
 		}
@@ -317,7 +317,7 @@ namespace MaterialUI
 		[MenuItem("MaterialUI/Create/List/ListView", false, 13)]
 		private static void CreateListView()
 		{
-			theThing = GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/ComponentPrefabs/List Item/ListView.prefab", typeof(GameObject))) as GameObject;
+			theThing = GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/Runtime/ComponentPrefabs/List Item/ListView.prefab", typeof(GameObject))) as GameObject;
 			SetupObject("ListView");
 			theThing.GetComponent<RectTransform>().anchoredPosition = Vector2.zero;
 			theThing.GetComponent<RectTransform>().sizeDelta = Vector2.zero;
@@ -327,7 +327,7 @@ namespace MaterialUI
 		[MenuItem("MaterialUI/Create/List/Single-line item/Text only", false, 13)]
 		private static void CreateListItemSingle()
 		{
-			theThing = GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/ComponentPrefabs/List Item/List Item Single.prefab", typeof(GameObject))) as GameObject;
+			theThing = GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/Runtime/ComponentPrefabs/List Item/List Item Single.prefab", typeof(GameObject))) as GameObject;
 			SetupObject("List Item");
 			theThing.GetComponent<RectTransform>().anchoredPosition = Vector2.zero;
 		}
@@ -336,7 +336,7 @@ namespace MaterialUI
 		[MenuItem("MaterialUI/Create/List/Single-line item/Text with icon", false, 13)]
 		private static void CreateListItemSingleIcon()
 		{
-			theThing = GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/ComponentPrefabs/List Item/List Item Single Icon.prefab", typeof(GameObject))) as GameObject;
+			theThing = GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/Runtime/ComponentPrefabs/List Item/List Item Single Icon.prefab", typeof(GameObject))) as GameObject;
 			SetupObject("List Item");
 			theThing.GetComponent<RectTransform>().anchoredPosition = Vector2.zero;
 		}
@@ -345,7 +345,7 @@ namespace MaterialUI
 		[MenuItem("MaterialUI/Create/List/Single-line item/Text with avatar", false, 13)]
 		private static void CreateListItemSingleAvatar()
 		{
-			theThing = GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/ComponentPrefabs/List Item/List Item Single Avatar.prefab", typeof(GameObject))) as GameObject;
+			theThing = GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/Runtime/ComponentPrefabs/List Item/List Item Single Avatar.prefab", typeof(GameObject))) as GameObject;
 			SetupObject("List Item");
 			theThing.GetComponent<RectTransform>().anchoredPosition = Vector2.zero;
 		}
@@ -354,7 +354,7 @@ namespace MaterialUI
 		[MenuItem("MaterialUI/Create/List/Single-line item/Text Only", false, 13)]
 		private static void CreateListItemSingleIconAvatar()
 		{
-			theThing = GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/ComponentPrefabs/List Item/List Item Single Icon Avatar.prefab", typeof(GameObject))) as GameObject;
+			theThing = GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/Runtime/ComponentPrefabs/List Item/List Item Single Icon Avatar.prefab", typeof(GameObject))) as GameObject;
 			SetupObject("List Item");
 			theThing.GetComponent<RectTransform>().anchoredPosition = Vector2.zero;
 		}
@@ -363,7 +363,7 @@ namespace MaterialUI
 		[MenuItem("MaterialUI/Create/List/Double-line item/Text only", false, 13)]
 		private static void CreateListItemDouble()
 		{
-			theThing = GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/ComponentPrefabs/List Item/List Item Double.prefab", typeof(GameObject))) as GameObject;
+			theThing = GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/Runtime/ComponentPrefabs/List Item/List Item Double.prefab", typeof(GameObject))) as GameObject;
 			SetupObject("List Item");
 			theThing.GetComponent<RectTransform>().anchoredPosition = Vector2.zero;
 		}
@@ -372,7 +372,7 @@ namespace MaterialUI
 		[MenuItem("MaterialUI/Create/List/Double-line item/Text with icon", false, 13)]
 		private static void CreateListItemDoubleIcon()
 		{
-			theThing = GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/ComponentPrefabs/List Item/List Item Double Icon.prefab", typeof(GameObject))) as GameObject;
+			theThing = GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/Runtime/ComponentPrefabs/List Item/List Item Double Icon.prefab", typeof(GameObject))) as GameObject;
 			SetupObject("List Item");
 			theThing.GetComponent<RectTransform>().anchoredPosition = Vector2.zero;
 		}
@@ -381,7 +381,7 @@ namespace MaterialUI
 		[MenuItem("MaterialUI/Create/List/Double-line item/Text with avatar", false, 13)]
 		private static void CreateListItemDoubleAvatar()
 		{
-			theThing = GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/ComponentPrefabs/List Item/List Item Double Avatar.prefab", typeof(GameObject))) as GameObject;
+			theThing = GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/Runtime/ComponentPrefabs/List Item/List Item Double Avatar.prefab", typeof(GameObject))) as GameObject;
 			SetupObject("List Item");
 			theThing.GetComponent<RectTransform>().anchoredPosition = Vector2.zero;
 		}
@@ -390,7 +390,7 @@ namespace MaterialUI
 		[MenuItem("MaterialUI/Create/List/Double-line item/Text Only", false, 13)]
 		private static void CreateListItemDoubleIconAvatar()
 		{
-			theThing = GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/ComponentPrefabs/List Item/List Item Double Icon Avatar.prefab", typeof(GameObject))) as GameObject;
+			theThing = GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/Runtime/ComponentPrefabs/List Item/List Item Double Icon Avatar.prefab", typeof(GameObject))) as GameObject;
 			SetupObject("List Item");
 			theThing.GetComponent<RectTransform>().anchoredPosition = Vector2.zero;
 		}
@@ -399,7 +399,7 @@ namespace MaterialUI
 		[MenuItem("MaterialUI/Create/List/Triple-line item/Text only", false, 13)]
 		private static void CreateListItemTriple()
 		{
-			theThing = GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/ComponentPrefabs/List Item/List Item Triple.prefab", typeof(GameObject))) as GameObject;
+			theThing = GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/Runtime/ComponentPrefabs/List Item/List Item Triple.prefab", typeof(GameObject))) as GameObject;
 			SetupObject("List Item");
 			theThing.GetComponent<RectTransform>().anchoredPosition = Vector2.zero;
 		}
@@ -408,7 +408,7 @@ namespace MaterialUI
 		[MenuItem("MaterialUI/Create/List/Triple-line item/Text with icon", false, 13)]
 		private static void CreateListItemTripleIcon()
 		{
-			theThing = GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/ComponentPrefabs/List Item/List Item Triple Icon.prefab", typeof(GameObject))) as GameObject;
+			theThing = GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/Runtime/ComponentPrefabs/List Item/List Item Triple Icon.prefab", typeof(GameObject))) as GameObject;
 			SetupObject("List Item");
 			theThing.GetComponent<RectTransform>().anchoredPosition = Vector2.zero;
 		}
@@ -417,7 +417,7 @@ namespace MaterialUI
 		[MenuItem("MaterialUI/Create/List/Triple-line item/Text with avatar", false, 13)]
 		private static void CreateListItemTripleAvatar()
 		{
-			theThing = GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/ComponentPrefabs/List Item/List Item Triple Avatar.prefab", typeof(GameObject))) as GameObject;
+			theThing = GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/Runtime/ComponentPrefabs/List Item/List Item Triple Avatar.prefab", typeof(GameObject))) as GameObject;
 			SetupObject("List Item");
 			theThing.GetComponent<RectTransform>().anchoredPosition = Vector2.zero;
 		}
@@ -426,7 +426,7 @@ namespace MaterialUI
 		[MenuItem("MaterialUI/Create/List/Triple-line item/Text Only", false, 13)]
 		private static void CreateListItemTripleIconAvatar()
 		{
-			theThing = GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/ComponentPrefabs/List Item/List Item Triple Icon Avatar.prefab", typeof(GameObject))) as GameObject;
+			theThing = GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/Runtime/ComponentPrefabs/List Item/List Item Triple Icon Avatar.prefab", typeof(GameObject))) as GameObject;
 			SetupObject("List Item");
 			theThing.GetComponent<RectTransform>().anchoredPosition = Vector2.zero;
 		}
@@ -438,7 +438,7 @@ namespace MaterialUI
 		private static void CreateNavDrawer()
 		{
 			theThing =
-				GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/ComponentPrefabs/Nav Drawer.prefab",
+				GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/Runtime/ComponentPrefabs/Nav Drawer.prefab",
 					typeof (GameObject))) as GameObject;
 			SetupObject("Nav Drawer");
 			theThing.GetComponent<RectTransform>().sizeDelta = new Vector2(theThing.GetComponent<RectTransform>().sizeDelta.x, 8f);
@@ -451,7 +451,7 @@ namespace MaterialUI
 		private static void CreateAppBar()
 		{
 			theThing =
-				GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/ComponentPrefabs/App Bar.prefab",
+				GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/Runtime/ComponentPrefabs/App Bar.prefab",
 					typeof (GameObject))) as GameObject;
 			SetupObject("App Bar");
 			theThing.GetComponent<RectTransform>().sizeDelta = Vector2.zero;
@@ -463,7 +463,7 @@ namespace MaterialUI
 		private static void CreateScreenManager()
 		{
 			theThing =
-				GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/ComponentPrefabs/ScreenManager.prefab",
+				GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/Runtime/ComponentPrefabs/ScreenManager.prefab",
 					typeof(GameObject))) as GameObject;
 			SetupObject("Screen Manager");
 			theThing.GetComponent<RectTransform>().sizeDelta = Vector2.zero;
@@ -475,7 +475,7 @@ namespace MaterialUI
 		private static void CreateScreen()
 		{
 			theThing =
-				GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/ComponentPrefabsH/Screen.prefab",
+				GameObject.Instantiate(AssetDatabase.LoadAssetAtPath("Packages/com.battlefieldnoob.uimaterialelements/Runtime/ComponentPrefabs/Screen.prefab",
 					typeof (GameObject))) as GameObject;
 			SetupObject("Screen");
 			theThing.GetComponent<RectTransform>().sizeDelta = Vector2.zero;


### PR DESCRIPTION
Referenced issue: #3

The path to the ComponentPrefabs folder was wrongly defined in the MaterialUIEditorTools editor class (which creates the MaterialUI hierarchy menu element), throwing a NullPointerException because the prefabs couldn't be found.

Other little details found (unrelated with the issue, but worth to mention):

- "Slider with text" and "Slider with text and value" are slightly less clickeable than the default "Slider" component (the click area is smaller, making it harder to drag).

- The prefabs of both selection boxes components have the "SelectionBoxSubscriber" monobehaviour script attached to their "SelectionLayer" gameobjects. So, when an item is selected, there's a Debug.Log printed in the console (maybe we should remove that script from the prefab itself).